### PR TITLE
10 Support for ccsds packet encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This system simulates satellite telemetry data, streams it through Kafka, proces
 - **Basilisk Simulation**: Generates telemetry data simulating satellite conditions. 
 - **PostgreSQL**: Stores historical telemetry data. 
 - **Middleware (`middleware.py`)**: Reads data from PostgreSQL, injects simulation metadata, and streams it into Kafka. 
-- **Kafka & Zookeeper**: Provides a high-throughput messaging backbone for real-time data ingestion. 
+- **Kafka**: Provides a high-throughput messaging backbone for real-time data ingestion. 
 - **Telegraf & InfluxDB**: Telegraf consumes Kafka messages and writes metrics into InfluxDB, a time-series database. 
 - **Anomaly Detection**: Consumes data from Kafka to detect anomalies at both constellation and satellite levels. Results are written to InfluxDB. 
 - **Grafana**: Visualizes telemetry data and anomalies, enabling users to explore trends and anomalies over time. 
@@ -57,7 +57,7 @@ cd Sat-Fault-Detection
 docker-compose build 
 docker-compose up -d
 ```
-This starts PostgreSQL, Kafka, Zookeeper, Telegraf, InfluxDB, Grafana, and the anomaly detection service.
+This starts PostgreSQL, Kafka, Telegraf, InfluxDB, Grafana, and the anomaly detection service.
 
 ## Usage
 To use the system, you can interact with each container by opening its terminal either by running `docker-compose up -it <name_of_container>` or opening the terminal under Docker Desktop. 

--- a/ccsds-ingest-container/Dockerfile
+++ b/ccsds-ingest-container/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . /app
+RUN pip install confluent-kafka influxdb
+CMD ["python", "ccsds_ingest.py"]

--- a/ccsds-ingest-container/ccsds_config/sample_config.json
+++ b/ccsds-ingest-container/ccsds_config/sample_config.json
@@ -1,0 +1,26 @@
+{
+    "ccsds": {
+      "header": {
+        "length": 7,
+        "fields": {
+          "version": { "offset": 0, "length": 1, "type": "uint8" },
+          "satellite_id": { "offset": 1, "length": 1, "type": "uint8" },
+          "packet_id": { "offset": 2, "length": 1, "type": "uint8" },
+          "timestamp": { "offset": 3, "length": 4, "type": "uint32", "optional": true }
+        }
+      },
+      "data_field": {
+        "length": 12,
+        "fields": [
+          { "name": "battery_voltage", "offset": 0, "length": 4, "type": "float" },
+          { "name": "battery_current", "offset": 4, "length": 4, "type": "float" },
+          { "name": "temperature", "offset": 8, "length": 4, "type": "float" }
+        ]
+      },
+      "crc_length": 2
+    },
+    "aggregation": {
+      "time_window": 1
+    }
+  }
+  

--- a/ccsds-ingest-container/ccsds_ingest.py
+++ b/ccsds-ingest-container/ccsds_ingest.py
@@ -1,0 +1,179 @@
+import json
+import struct
+import time
+import logging
+from datetime import datetime
+from collections import defaultdict
+from confluent_kafka import Consumer, KafkaError
+from influxdb import InfluxDBClient
+
+# configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("ccsds_ingest")
+
+with open('./ccsds_config/sample_config.json', 'r') as f:
+    config = json.load(f)
+
+ccsds_conf = config['ccsds']
+aggregation_window = config.get('aggregation', {}).get('time_window', 1)
+
+# expected packet length = header length + data field length + crc length
+expected_packet_length = ccsds_conf['header']['length'] + ccsds_conf['data_field']['length'] + ccsds_conf.get('crc_length', 0)
+
+def parse_field(data, offset, length, field_type):
+    segment = data[offset:offset+length]
+    if field_type == "uint8":
+        return struct.unpack("B", segment)[0]
+    elif field_type == "uint32":
+        return struct.unpack(">I", segment)[0]  # big-endian unsigned int (assume big-endian format for CCSDS)
+    elif field_type == "float":
+        return struct.unpack(">f", segment)[0]  # big-endian float
+    else:
+        raise ValueError(f"Unsupported field type: {field_type}")
+
+def parse_packet(packet_bytes):
+    if len(packet_bytes) != expected_packet_length:
+        logger.error("Packet length does not match expected length")
+        return None
+
+    # parse header
+    header_conf = ccsds_conf['header']
+    header = {}
+    for field, spec in header_conf['fields'].items():
+        offset = spec['offset']
+        length = spec['length']
+        try:
+            header[field] = parse_field(packet_bytes, offset, length, spec['type'])
+        except Exception as e:
+            logger.error(f"Error parsing header field {field}: {e}")
+            return None
+
+    # use header timestamp if available or current time
+    packet_time = header.get("timestamp")
+    if not packet_time or packet_time == 0:
+        packet_time = int(time.time())
+    else:
+        # if needed, convert the header timestamp to Unix seconds
+        packet_time = int(packet_time)
+
+    # parse data field
+    data_field_conf = ccsds_conf['data_field']
+    data_field = {}
+    data_field_offset = header_conf['length']  # daata field starts immediately after header
+    for field in data_field_conf['fields']:
+        name = field['name']
+        offset = data_field_offset + field['offset']
+        length = field['length']
+        try:
+            data_field[name] = parse_field(packet_bytes, offset, length, field['type'])
+        except Exception as e:
+            logger.error(f"Error parsing data field {name}: {e}")
+
+    # assume CRC error correction is valid
+
+    # use satellite_id from header; if not present, assign one externally
+    satellite_id = header.get("satellite_id", None)
+    return {
+        "time": packet_time,
+        "satellite_id": satellite_id,
+        "data": data_field
+    }
+
+# Buffer for aggregation - keyed by satellite_id and timestamp rounded to the aggregation window
+aggregation_buffer = defaultdict(dict)
+
+def aggregate_packet(parsed_packet):
+
+    key = (parsed_packet["satellite_id"], parsed_packet["time"] // aggregation_window)
+
+    # merge new fields into existing aggregated data
+    aggregation_buffer[key]["time"] = parsed_packet["time"]
+    aggregation_buffer[key]["satellite_id"] = parsed_packet["satellite_id"]
+
+    if "data" not in aggregation_buffer[key]:
+        aggregation_buffer[key]["data"] = {}
+
+    aggregation_buffer[key]["data"].update(parsed_packet["data"])
+
+def flush_aggregated_packets(influx_client):
+
+    current_time = int(time.time())
+    keys_to_flush = []
+    for key, record in aggregation_buffer.items():
+        # if the record is older than the aggregation window, flush it
+        if current_time - record["time"] >= aggregation_window:
+            write_to_influx(influx_client, record)
+            keys_to_flush.append(key)
+
+    # Remove flushed records from buffer
+    for key in keys_to_flush:
+        del aggregation_buffer[key]
+
+def write_to_influx(client, record):
+    # prepare InfluxDB point (using measurement "telemetry_data")
+    json_body = [
+        {
+            "measurement": "telemetry_data",
+            "tags": {
+                "satellite_id": str(record["satellite_id"])
+            },
+            "time": datetime.utcfromtimestamp(record["time"]).isoformat() + "Z",
+            "fields": {
+                "data": json.dumps(record["data"])
+            }
+        }
+    ]
+    try:
+        client.write_points(json_body)
+        logger.info(f"Wrote record to InfluxDB: {json_body}")
+    except Exception as e:
+        logger.error(f"Error writing to InfluxDB: {e}")
+
+def main():
+    # Kafka consumer configuration
+    consumer_conf = {
+        'bootstrap.servers': 'kafka:9092',
+        'group.id': 'ccsds_ingest_group',
+        'auto.offset.reset': 'earliest'
+    }
+    consumer = Consumer(consumer_conf)
+    consumer.subscribe(['raw_telemetry'])  # Topic that has raw telemetry streams
+
+    # Connect to InfluxDB - influx binds to port 8086 in its own Dockerfile
+    influx_client = InfluxDBClient(host='influx_telegraf', port=8086, database='telemetry_db')
+
+    try:
+        while True:
+            msg = consumer.poll(1.0)
+            if msg is None:
+                # no message received, flush any aggregated packets periodically.
+                flush_aggregated_packets(influx_client)
+                continue
+            if msg.error():
+                if msg.error().code() == KafkaError._PARTITION_EOF:
+                    continue
+                else:
+                    logger.error("Kafka error: {}".format(msg.error()))
+                    continue
+
+            raw_bytes = msg.value()
+            # determine if the message is a CCSDS bytestream by checking the packet length.
+            if len(raw_bytes) == expected_packet_length:
+                parsed = parse_packet(raw_bytes)
+                if parsed:
+                    aggregate_packet(parsed)
+
+                
+            else:
+                # bypass: forward the message as-is or ignore.
+                logger.info("Received non-CCSDS stream - bypassing translation.")
+
+            # Flush aggregated records at each iteration.
+            flush_aggregated_packets(influx_client)
+    except Exception as e:
+        logger.error(f"Unhandled exception: {e}")
+    finally:
+        consumer.close()
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,27 +13,20 @@ services:
       POSTGRES_DB: telemetry_db
     depends_on:
       - kafka
-    restart: always  # Ensures the container restarts on failure
+    restart: always
     networks:
       - telemetry-network
 
   kafka:
     image: bitnami/kafka:latest
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: PLAINTEXT://:9092
+      # Required for KRaft mode:
+      KAFKA_CFG_PROCESS_ROLES: broker,controller
+      KAFKA_CFG_NODE_ID: "1"
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-    depends_on:
-      - zookeeper
-    restart: always
-    networks:
-      - telemetry-network
-
-  zookeeper:
-    image: bitnami/zookeeper:latest
-    environment:
-      ALLOW_ANONYMOUS_LOGIN: 'yes'
+      # Note: Remove KAFKA_ZOOKEEPER_CONNECT since it's not needed in KRaft mode.
     restart: always
     networks:
       - telemetry-network
@@ -75,7 +68,8 @@ services:
       - telemetry-network
 
 volumes:
-  influx_telegraf_data:
+  # removed volume for influx to avoid front-end persists, can be added back if helps
+#   influx_telegraf_data:
   pgdata:
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,77 +1,89 @@
 version: '3.8'
 
 services:
-  sim_middleware:
-    build: ./simulation-container
-    volumes:
-      - ./simulation-container/simulations:/basilisk/simulations
-      - ./simulation-container/middleware.py:/basilisk/middleware.py
-      - pgdata:/var/lib/postgresql/data
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: telemetry_db
-    depends_on:
-      - kafka
-    restart: always
-    networks:
-      - telemetry-network
+    sim_middleware:
+        build: ./simulation-container
+        volumes:
+        - ./simulation-container/simulations:/basilisk/simulations
+        - ./simulation-container/middleware.py:/basilisk/middleware.py
+        - pgdata:/var/lib/postgresql/data
+        environment:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: postgres
+            POSTGRES_DB: telemetry_db
+        depends_on:
+        - kafka
+        restart: always
+        networks:
+        - telemetry-network
 
-  kafka:
-    image: bitnami/kafka:latest
-    environment:
-      KAFKA_CFG_PROCESS_ROLES: broker,controller        # Enable both broker and controller roles
-      KAFKA_CFG_NODE_ID: "1"                            # Unique ID for this Kafka node
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER   # Define the listener name that the controller should use
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"        # default quorum for a single node
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
-      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-    restart: always
-    networks:
-      - telemetry-network
+    kafka:
+        image: bitnami/kafka:latest
+        environment:
+            KAFKA_CFG_PROCESS_ROLES: broker,controller        # Enable both broker and controller roles
+            KAFKA_CFG_NODE_ID: "1"                            # Unique ID for this Kafka node
+            KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER   # Define the listener name that the controller should use
+            KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"        # default quorum for a single node
+            KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+            KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+            KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+        restart: always
+        networks:
+        - telemetry-network
 
-  influx_telegraf:
-    build: ./influx_telegraf-container
-    volumes:
-      - ./influx_telegraf-container/influxdb.conf:/etc/influxdb/influxdb.conf
-      - ./influx_telegraf-container/telegraf.conf:/etc/telegraf/telegraf.conf
-    depends_on:
-      - kafka
-    networks:
-      - telemetry-network
+    ccsds_ingest:
+        build: ./ccsds-ingest-container
+        volumes:
+        - ./ccsds-ingest-container/ccsds_ingest.py:/app/ccsds_ingest.py
+        - ./ccsds-ingest-container/ccsds_config.json:/app/ccsds_config.json
+        depends_on:
+        - kafka
+        - influx_telegraf
+        restart: always
+        networks:
+        - telemetry-network
 
-  anomaly_detection:
-    build: ./anomaly-detection-container
-    volumes:
-      - ./anomaly-detection-container:/app
-      - ./anomaly-detection-container/models:/app/models
-      - ./anomaly-detection-container/config.json:/app/config.json
-    depends_on:
-      - kafka
-      - influx_telegraf
-    restart: always
-    networks:
-      - telemetry-network
+    influx_telegraf:
+        build: ./influx_telegraf-container
+        volumes:
+        - ./influx_telegraf-container/influxdb.conf:/etc/influxdb/influxdb.conf
+        - ./influx_telegraf-container/telegraf.conf:/etc/telegraf/telegraf.conf
+        depends_on:
+        - kafka
+        networks:
+        - telemetry-network
 
-  grafana:
-    build: ./grafana
-    ports:
-      - "3000:3000"
-    volumes:
-      - ./grafana/provisioning:/etc/grafana/provisioning
-      - ./grafana/provisioning/dashboards:/var/lib/grafana/dashboards
-    depends_on:
-      - influx_telegraf
-    restart: always
-    networks:
-      - telemetry-network
+    anomaly_detection:
+        build: ./anomaly-detection-container
+        volumes:
+        - ./anomaly-detection-container:/app
+        - ./anomaly-detection-container/models:/app/models
+        - ./anomaly-detection-container/config.json:/app/config.json
+        depends_on:
+        - kafka
+        - influx_telegraf
+        restart: always
+        networks:
+        - telemetry-network
+
+    grafana:
+        build: ./grafana
+        ports:
+        - "3000:3000"
+        volumes:
+        - ./grafana/provisioning:/etc/grafana/provisioning
+        - ./grafana/provisioning/dashboards:/var/lib/grafana/dashboards
+        depends_on:
+        - influx_telegraf
+        restart: always
+        networks:
+        - telemetry-network
 
 volumes:
-  # removed volume for influx to avoid front-end persists, can be added back if helps
-#   influx_telegraf_data:
-  pgdata:
+    # removed volume for influx to avoid front-end persists, can be added back if helps
+    # influx_telegraf_data:
+    pgdata:
 
 networks:
-  telemetry-network:
-    driver: bridge
+    telemetry-network:
+        driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,13 @@ services:
   kafka:
     image: bitnami/kafka:latest
     environment:
-      # Required for KRaft mode:
-      KAFKA_CFG_PROCESS_ROLES: broker,controller
-      KAFKA_CFG_NODE_ID: "1"
+      KAFKA_CFG_PROCESS_ROLES: broker,controller        # Enable both broker and controller roles
+      KAFKA_CFG_NODE_ID: "1"                            # Unique ID for this Kafka node
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER   # Define the listener name that the controller should use
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"        # default quorum for a single node
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
       KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      # Note: Remove KAFKA_ZOOKEEPER_CONNECT since it's not needed in KRaft mode.
     restart: always
     networks:
       - telemetry-network


### PR DESCRIPTION
This PR introduces the following features and QOL changes:

- Upgrades Kafka to 2.8+ and removes dependency on Zookeeper for topic management using KRaft
- Fixed a bug where Kafka would restart if it didn't get data for a period of time
- Created system and container for ingest of raw telemetry bytestream data according to the [CCSDS format](https://public.ccsds.org/Pubs/132x0b3.pdf)
- Added configuration setups to allow for support of different datastream formats and varying byte sizes for metadata fields
- Updated documentation

### Future Improvements / Issues
There isn't full support for the CCSDS formats (I didn't understand and get through the entire standards packet), and so there may be many other standard formats and structures which aren't currently supported. These can be added in later PRs.